### PR TITLE
メッセージ保存画面のコメント入力機能の追加

### DIFF
--- a/front/src/components/AfterSaving/AfterSaving.css
+++ b/front/src/components/AfterSaving/AfterSaving.css
@@ -1,0 +1,41 @@
+
+.messageInput {
+    position: relative;
+    left: 0px;
+    top: 80px;
+    height: 50px;
+    width: 100%;
+}
+
+.messageText {
+    position: absolute;
+    left: 24px;
+    top: 0px;
+    width: 235px;
+    height: 32px;
+    margin: 0px;
+    padding-left: 5px;
+    padding-right: 5px;
+    font-size: 16px;
+    border: solid 4px black;
+    color: #000000;
+}
+
+.submitButton {
+    position: absolute;
+    width: 77px;
+    height: 40px;
+    left: 275px;
+    top: 0px;
+    line-height: 0px;
+    align-items: center;
+    text-align: center;
+    margin: 0px;
+    padding: 0px;
+    background: #000000;
+    border-radius: 0px;
+    color: white;
+    border: solid 0px #000000;
+    font-size: 20px;
+    z-index: 5;
+}

--- a/front/src/components/AfterSaving/AfterSaving.js
+++ b/front/src/components/AfterSaving/AfterSaving.js
@@ -1,37 +1,50 @@
 import React from 'react';
+import { useDispatch } from "react-redux";
+import movieCommentsModule, { useMovieComments } from "../../modules/movieCommentsModule";
 import Header from '../Header/Header';
 import Footer from '../Footer/Footer';
 import image_film from '../../image/image_film_short.svg';
-import send_button from '../../image/send_botton.svg';
 import './AfterSaving.css';
 
 function AfterSaving() {
+    let messageText = "";
+    const dispatch = useDispatch();
+    const onChangeMessage = (e) => { messageText = e.target.value };
+    const onSubmitMessage = () => {
+        // messageTextがnullか空のときは何もしない
+        if (!messageText) {
+            // デバック用，あとで消す
+            console.log("送信できません");
+            return;
+        }
+
+        // デバック用，あとで消す
+        console.log("送信完了");
+        // tokenと一緒にメッセージ内容をreduxに渡し，保存する
+        dispatch(movieCommentsModule.actions.saveMessageInput(messageText));
+    };
 
     return (
         <>
         <Header displayLogoReturn={false} LifeTime={true} MyPageLogo={true} title="受信箱"/>
         <Footer displayColor />
             
-            <div className="App-body">
-                <div>
-                    <img src={image_film} className="Content-film-short" alt="logo" /> 
-                </div>
-
-                <div className="Button">
-                    <button className="btn-square-left">いいね</button>
-                    <button href="AfterSaving" className="btn-square-center">閲覧済み</button>
-                    <button className="btn-square-right">報告</button>
-                </div>
-                
-                {/* <div>
-                    <img src={send_button} className="Send-Button" alt="logo" />
-                </div> */}
-
-                <form className="messageInput">
-                    <input className="messageText" type="text" placeholder="メッセージを入力" defaultValue="" /><br/>
-                    <button className="submitButton" type="submit">投稿</button>
-                </form>
+        <div className="App-body">
+            <div>
+                <img src={image_film} className="Content-film-short" alt="logo" /> 
             </div>
+
+            <div className="Button">
+                <button className="btn-square-left">いいね</button>
+                <button href="AfterSaving" className="btn-square-center">閲覧済み</button>
+                <button className="btn-square-right">報告</button>
+            </div>
+
+            <form className="messageInput" onSubmit={onSubmitMessage}>
+                <input className="messageText" type="text" placeholder="メッセージを入力" onChange={onChangeMessage} defaultValue=""/><br/>
+                <button className="submitButton" type="submit">投稿</button>
+            </form>
+        </div>
         </>
     );
 }

--- a/front/src/components/AfterSaving/AfterSaving.js
+++ b/front/src/components/AfterSaving/AfterSaving.js
@@ -1,18 +1,14 @@
 import React from 'react';
 import Header from '../Header/Header';
 import Footer from '../Footer/Footer';
-import { useMovieComments } from "../../modules/movieCommentsModule";
 import image_film from '../../image/image_film_short.svg';
 import send_button from '../../image/send_botton.svg';
+import './AfterSaving.css';
 
 function AfterSaving() {
-    const test = useMovieComments();
-    // let test2 = useSelector(state => state);
-    console.log("AfterSaving");
-    console.log(test);
 
     return (
-        <div>
+        <>
         <Header displayLogoReturn={false} LifeTime={true} MyPageLogo={true} title="受信箱"/>
         <Footer displayColor />
             
@@ -27,11 +23,16 @@ function AfterSaving() {
                     <button className="btn-square-right">報告</button>
                 </div>
                 
-                <div>
+                {/* <div>
                     <img src={send_button} className="Send-Button" alt="logo" />
-                </div>
+                </div> */}
+
+                <form className="messageInput">
+                    <input className="messageText" type="text" placeholder="メッセージを入力" defaultValue="" /><br/>
+                    <button className="submitButton" type="submit">投稿</button>
+                </form>
             </div>
-        </div>
+        </>
     );
 }
 

--- a/front/src/components/Form/Form.js
+++ b/front/src/components/Form/Form.js
@@ -5,8 +5,7 @@ export default class Form extends Component {
 
 render() {
     return (
-        <div className="Form">
-            <form name="todoform" onSubmit={this.props.onSubmit}>
+        <form name="todoform" onSubmit={this.props.onSubmit}>
             <input name="title" type="text" placeholder="タイトルを入力" defaultValue="" /><br/>
             <select className="Select">
                 <option value="" hidden>ジャンルを選択</option>
@@ -21,8 +20,7 @@ render() {
             <textarea id="onef" name="onef" placeholder="ひとこと" defaultValue=""></textarea><br/>
             <textarea id="desc" name="desc" placeholder="本文" defaultValue=""></textarea><br/>
             <button type="submit">投稿</button>
-            </form>
-        </div>
+        </form>
     );
     }
 }

--- a/front/src/modules/movieCommentsModule.js
+++ b/front/src/modules/movieCommentsModule.js
@@ -4,6 +4,8 @@ import { useSelector } from "react-redux";
 const movieCommentsInitialState = {
     selectedCommentId: 0,
 
+    messageInput: [],
+
     list: [
         {
             id: 1,
@@ -42,6 +44,7 @@ const movieCommentsModule = createSlice({
     slice: "movieComments",
     initialState: movieCommentsInitialState,
     reducers: {
+        // いいねの状態を変更する
         changeLikeState: (state, action) => {
             const id = action.payload;  
             state.list.forEach(comment => {
@@ -50,16 +53,23 @@ const movieCommentsModule = createSlice({
             });
         },
 
+        // どのカチンコが選択されたかをIDで記憶する
         setSelectedId: (state, action) => {
             const id = action.payload;
-            console.log("setSelectedId, reducer")
             state.selectedCommentId = id;
         },
 
-        // add: (state, action) => {(state+1)},
+        // ユーザ（あるいはトークン）と一緒にメッセージ内容を保存する
+        saveMessageInput: (state, action) => {
+            const text = action.payload;
+            // token(or User)はとりあえず固定（後で変更する）
+            const token = "9y7DyLFXQqVFsESjPNSBV9fq";
+            state.messageInput.push({ token: {token}, text: {text} });
+        },
     }
 });
 
+// stateの中身を確認するために使用している（後で変更する）
 export const useMovieComments = () => {return useSelector(state => state);};
 
 export default movieCommentsModule;


### PR DESCRIPTION
### 概要
メッセージ保存画面でメッセージ作成者宛てにコメントを送ることができるコメント入力機能を実装した（下記画像の「メッセージを入力」の部分）
Close #37 

<img src="https://user-images.githubusercontent.com/30923698/66735592-baa48400-eea1-11e9-970f-7e608a974646.png" width=200>


### やったこと
- Formタグを使用し，コメント入力機能を追加
- CSSでフォームの見た目を調整
- 送信ボタンを押した後，reduxにトークン（現状，適当な値）とコメント内容を辞書(dict)形式で保存

### 課題
データをjson形式に変換し，バックエンド側とAPIでデータをやり取り出来るようにしたい