### PR TITLE
「いいね」「保存」「メッセージの送信」による変更をlocal storage上のredux stateに適用できるように変更した

### DIFF
--- a/front/src/components/AfterSaving/AfterSaving.js
+++ b/front/src/components/AfterSaving/AfterSaving.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import movieCommentsModule, { useMovieComments } from "../../modules/movieCommentsModule";
 import Header from '../Header/Header';
 import Footer from '../Footer/Footer';
@@ -12,8 +12,64 @@ import SaveAltIcon from '@material-ui/icons/SaveAlt';
 import ReportIcon from '@material-ui/icons/Report';
 import Fab from '@material-ui/core/Fab';
 
-function AfterSaving() {
+const useStyles = makeStyles(theme => ({
+    button:{
+        width: "21px",
+        marginRight: theme.spacing(1),
+        '&:hover': {
+            background: 'black'
+        }
+    },
+
+    like: ({ likeState }) => ({
+        width: "16px",
+        color: likeState ? "red" : "white",
+        marginRight: theme.spacing(1),
+        '&:hover': {
+            background: 'black'
+        }
+    }),
+
+    save: {
+        width: "21px",
+        color: "#33cc30",
+        marginRight: theme.spacing(1),
+        '&:hover': {
+            background: 'black'
+        }
+    },
+
+    background: {
+        color: "white",
+        width: "100px",
+        height: "37px",
+        backgroundColor: "black",
+        '&:hover': {
+            background: 'black'
+        }
+    },
+
+    submit: {
+        display: "relative",
+        color: "white",
+        width: "77px",
+        height: "40px",
+        left: 274,
+        top: 0,
+        fontSize: 19,
+        padding: 0,
+        margin: 0,
+        backgroundColor: "black",
+        '&:hover': {
+            background: 'black'
+        }
+    },
+}));
+
+const AfterSaving = () => {
     let messageText = "";
+    const useSelectedId = () => {return useSelector(state => state["movieComments"].selectedCommentId);};
+    const id = useSelectedId()
     const dispatch = useDispatch();
     const onChangeMessage = (e) => { messageText = e.target.value };
     const onSubmitMessage = () => {
@@ -30,60 +86,6 @@ function AfterSaving() {
         dispatch(movieCommentsModule.actions.saveMessageInput(messageText));
     };
 
-    const useStyles = makeStyles(theme => ({
-        button:{
-            width: "21px",
-            marginRight: theme.spacing(1),
-            '&:hover': {
-                background: 'black'
-            }
-        },
-    
-        like: ({ likeState }) => ({
-            width: "16px",
-            color: likeState ? "red" : "white",
-            marginRight: theme.spacing(1),
-            '&:hover': {
-                background: 'black'
-            }
-        }),
-    
-        save: {
-            width: "21px",
-            color: "#33cc30",
-            marginRight: theme.spacing(1),
-            '&:hover': {
-                background: 'black'
-            }
-        },
-
-        background: {
-            color: "white",
-            width: "100px",
-            height: "37px",
-            backgroundColor: "black",
-            '&:hover': {
-                background: 'black'
-            }
-        },
-
-        submit: {
-            display: "relative",
-            color: "white",
-            width: "77px",
-            height: "40px",
-            left: 274,
-            top: 0,
-            fontSize: 19,
-            padding: 0,
-            margin: 0,
-            backgroundColor: "black",
-            '&:hover': {
-                background: 'black'
-            }
-        },
-    }));
-
     const [likeState, setLikeState] = useState(false);
     const classes = useStyles({ likeState });
 
@@ -91,9 +93,9 @@ function AfterSaving() {
         <>
         <Header displayLogoReturn={false} LifeTime={true} MyPageLogo={true} title="受信箱"/>
         <Footer displayColor />
-            
+
         <div className="App-body1">
-            <img src={image_film} className="film-short" alt="logo" /> 
+            <img src={image_film} className="film-short" alt="logo" />
 
             <div className="buttonList">
                 <Fab variant="extended" className={classes.background} onClick={() => setLikeState(!likeState)} >

--- a/front/src/components/AfterSaving/AfterSaving.js
+++ b/front/src/components/AfterSaving/AfterSaving.js
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { useDispatch, useSelector } from "react-redux";
+import React from 'react';
+import { useDispatch } from "react-redux";
 import movieCommentsModule, { useMovieComments } from "../../modules/movieCommentsModule";
 import Header from '../Header/Header';
 import Footer from '../Footer/Footer';
@@ -30,14 +30,14 @@ const useStyles = makeStyles(theme => ({
         }
     }),
 
-    save: {
+    save: ({ saveState }) => ({
         width: "21px",
-        color: "#33cc30",
+        color: saveState ? "#33cc30" : "white",
         marginRight: theme.spacing(1),
         '&:hover': {
             background: 'black'
         }
-    },
+    }),
 
     background: {
         color: "white",
@@ -68,9 +68,13 @@ const useStyles = makeStyles(theme => ({
 
 const AfterSaving = () => {
     let messageText = "";
-    const useSelectedId = () => {return useSelector(state => state["movieComments"].selectedCommentId);};
-    const id = useSelectedId()
     const dispatch = useDispatch();
+    const reverseLikeState = () => dispatch(movieCommentsModule.actions.reverseLikeState());
+    const reverseSaveState = () => dispatch(movieCommentsModule.actions.reverseSaveState());
+    const id = useMovieComments()["movieComments"].selectedCommentId;
+    const comments = useMovieComments()["movieComments"].list
+    const likeState = comments.filter((comment) => comment.id === id)[0].isLikeState;
+    const saveState = comments.filter((comment) => comment.id === id)[0].isSaved;
     const onChangeMessage = (e) => { messageText = e.target.value };
     const onSubmitMessage = () => {
         // messageTextがnullか空のときは何もしない
@@ -86,8 +90,7 @@ const AfterSaving = () => {
         dispatch(movieCommentsModule.actions.saveMessageInput(messageText));
     };
 
-    const [likeState, setLikeState] = useState(false);
-    const classes = useStyles({ likeState });
+    const classes = useStyles({ likeState, saveState});
 
     return (
         <>
@@ -98,12 +101,12 @@ const AfterSaving = () => {
             <img src={image_film} className="film-short" alt="logo" />
 
             <div className="buttonList">
-                <Fab variant="extended" className={classes.background} onClick={() => setLikeState(!likeState)} >
+                <Fab variant="extended" className={classes.background} onClick={() => reverseLikeState()} >
                     <FavoriteIcon className={classes.like}/>
                     いいね
                 </Fab>
 
-                <Fab variant="extended" className={classes.background}>
+                <Fab variant="extended" className={classes.background} onClick={() => reverseSaveState()}>
                     <SaveAltIcon className={classes.save}/>
                     保存
                 </Fab>

--- a/front/src/components/ReceivedBox/ReceivedBox.js
+++ b/front/src/components/ReceivedBox/ReceivedBox.js
@@ -1,4 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { useDispatch } from "react-redux";
+import movieCommentsModule, { useMovieComments } from "../../modules/movieCommentsModule";
 import Header from '../Header/Header';
 import Footer from '../Footer/Footer';
 import image_film from '../../image/image_film_short.svg';
@@ -18,7 +20,7 @@ const useStyles = makeStyles(theme => ({
             background: 'black'
         }
     },
-    
+
     like: ({ likeState }) => ({
         width: "16px",
         color: likeState ? "red" : "white",
@@ -49,26 +51,31 @@ const useStyles = makeStyles(theme => ({
 }));
 
 function ReceivedBox() {
-    const [likeState, setLikeState] = useState(false);
-    const [saveState, setSaveState] = useState(false);
+    const dispatch = useDispatch();
+    const reverseLikeState = () => dispatch(movieCommentsModule.actions.reverseLikeState());
+    const reverseSaveState = () => dispatch(movieCommentsModule.actions.reverseSaveState());
+    const id = useMovieComments()["movieComments"].selectedCommentId;
+    const comments = useMovieComments()["movieComments"].list;
+    const likeState = comments.filter((comment) => comment.id === id)[0].isLikeState;
+    const saveState = comments.filter((comment) => comment.id === id)[0].isSaved;
     const classes = useStyles({ likeState, saveState });
 
     return (
         <>
         <Header displayLogoReturn={true} MyPageLogo={true} title="受信箱"/>
         <Footer/>
-            
+
         <div className="App-body">
             <img src={image_film} className="film-short" alt="logo" />
 
             <div className="buttonList">
-                <Fab variant="extended" className={classes.background} onClick={() => setLikeState(!likeState)} >
+                <Fab variant="extended" className={classes.background} onClick={() => reverseLikeState()} >
                     <FavoriteIcon className={classes.like}/>
                     いいね
                 </Fab>
 
                 <Link to="AfterSaving" className="Link">
-                    <Fab variant="extended" className={classes.background} onClick={() => setSaveState(!saveState)}>
+                    <Fab variant="extended" className={classes.background} onClick={() => reverseSaveState()}>
                         <SaveAltIcon className={classes.save}/>
                         保存
                     </Fab>

--- a/front/src/components/ReceivedList/ReceivedList.js
+++ b/front/src/components/ReceivedList/ReceivedList.js
@@ -6,7 +6,7 @@ import kachinko_close from "../../image/kachinko_large_close.svg";
 import { useDispatch, useSelector } from "react-redux";
 import movieCommentsModule from "../../modules/movieCommentsModule";
 
-function ReceivedList() {
+const ReceivedList = () => {
     // stateの確認用（あとで消す）
     // stateの中身を確認するために使用している（後で変更する）
     const useMovieComments = () => {return useSelector(state => state);};
@@ -17,11 +17,7 @@ function ReceivedList() {
     const dispatch = useDispatch();
     // 選ばれたカチンコのIDをstoreのSelectedIdに上書きする
     const setSelectedId = (id) => {
-        console.log(id+1);
         dispatch(movieCommentsModule.actions.setSelectedId(id+1));
-
-        console.log("-------------------");
-        console.log(useMovieComments);
     }
 
     return (

--- a/front/src/components/ReceivedList/ReceivedList.js
+++ b/front/src/components/ReceivedList/ReceivedList.js
@@ -3,14 +3,11 @@ import Header from "../Header/Header";
 import Footer from "../Footer/Footer";
 import kachinko_open from "../../image/kachinko_large_open.svg";
 import kachinko_close from "../../image/kachinko_large_close.svg";
-import { useDispatch, useSelector } from "react-redux";
-import movieCommentsModule from "../../modules/movieCommentsModule";
+import { useDispatch } from "react-redux";
+import movieCommentsModule, { useMovieComments } from "../../modules/movieCommentsModule";
 
 const ReceivedList = () => {
     // stateの確認用（あとで消す）
-    // stateの中身を確認するために使用している（後で変更する）
-    const useMovieComments = () => {return useSelector(state => state)};
-
     const state = useMovieComments()["movieComments"].list;
     console.log(useMovieComments()["movieComments"]);
 
@@ -38,9 +35,9 @@ const ReceivedList = () => {
 }
 
 const DisplayKachinko = ({review}) => {
-    const kachinkoType = (review.id===1) ? kachinko_open : kachinko_close;
+    const kachinkoType = (review.id===0) ? kachinko_open : kachinko_close;
     const className1 = "App-logo" + review.id;
-    const className2 = (review.id===1) ? "kachinko-open-title" : "kachinko-close-title";
+    const className2 = (review.id===0) ? "kachinko-open-title" : "kachinko-close-title";
 
     return(
         <>

--- a/front/src/components/ReceivedList/ReceivedList.js
+++ b/front/src/components/ReceivedList/ReceivedList.js
@@ -9,7 +9,7 @@ import movieCommentsModule from "../../modules/movieCommentsModule";
 const ReceivedList = () => {
     // stateの確認用（あとで消す）
     // stateの中身を確認するために使用している（後で変更する）
-    const useMovieComments = () => {return useSelector(state => state);};
+    const useMovieComments = () => {return useSelector(state => state)};
 
     const state = useMovieComments()["movieComments"].list;
     console.log(useMovieComments()["movieComments"]);
@@ -17,7 +17,7 @@ const ReceivedList = () => {
     const dispatch = useDispatch();
     // 選ばれたカチンコのIDをstoreのSelectedIdに上書きする
     const setSelectedId = (id) => {
-        dispatch(movieCommentsModule.actions.setSelectedId(id+1));
+        dispatch(movieCommentsModule.actions.setSelectedId(id));
     }
 
     return (

--- a/front/src/modules/movieCommentsModule.js
+++ b/front/src/modules/movieCommentsModule.js
@@ -1,4 +1,5 @@
 import { createSlice } from "redux-starter-kit";
+import { useSelector } from "react-redux";
 
 const movieCommentsInitialState = {
     selectedCommentId: 0,
@@ -49,11 +50,20 @@ const movieCommentsModule = createSlice({
         },
 
         // いいねの状態を変更する
-        changeLikeState: (state, action) => {
-            const id = action.payload;
+        reverseLikeState: (state, action) => {
+            const id = state.selectedCommentId;
             state.list.forEach(comment => {
                 comment.isLikeState =
                     comment.id === id ? !comment.isLikeState : comment.isLikeState;
+            });
+        },
+
+        // 保存の状態を変更する
+        reverseSaveState: (state, action) => {
+            const id = state.selectedCommentId;
+            state.list.forEach(comment => {
+                comment.isSaved =
+                    comment.id === id ? !comment.isSaved : comment.isSaved;
             });
         },
 
@@ -74,5 +84,7 @@ const movieCommentsModule = createSlice({
         },
     }
 });
+
+export const useMovieComments = () => { return useSelector(state => state); };
 
 export default movieCommentsModule;

--- a/front/src/modules/movieCommentsModule.js
+++ b/front/src/modules/movieCommentsModule.js
@@ -2,12 +2,9 @@ import { createSlice } from "redux-starter-kit";
 
 const movieCommentsInitialState = {
     selectedCommentId: 0,
-
-    messageInput: [],
-
     list: [
         {
-            id: 1,
+            id: 0,
             title: "タイトル1",
             genre: "ジャンル1",
             onePhrase: "ひとこと1",
@@ -15,9 +12,10 @@ const movieCommentsInitialState = {
             isLikeState: false,
             isSaved: false,
             imgType: "kachinko_open",
+            messageInput: "",
         },
         {
-            id: 2,
+            id: 1,
             title: "タイトル2",
             genre: "ジャンル2",
             onePhrase: "ひとこと2",
@@ -25,9 +23,10 @@ const movieCommentsInitialState = {
             isLikeState: false,
             isSaved: false,
             imgType: "kachinko_close",
+            messageInput: "",
         },
         {
-            id: 3,
+            id: 2,
             title: "タイトル3",
             genre: "ジャンル3",
             onePhrase: "ひとこと3",
@@ -35,6 +34,7 @@ const movieCommentsInitialState = {
             isLikeState: false,
             isSaved: false,
             imgType: "kachinko_close",
+            messageInput: "",
         },
     ]
 };
@@ -43,9 +43,14 @@ const movieCommentsModule = createSlice({
     slice: "movieComments",
     initialState: movieCommentsInitialState,
     reducers: {
+        // stateの状態を初期化する
+        initializeState: (state, action) => {
+            state = movieCommentsInitialState;
+        },
+
         // いいねの状態を変更する
         changeLikeState: (state, action) => {
-            const id = action.payload;  
+            const id = action.payload;
             state.list.forEach(comment => {
                 comment.isLikeState =
                     comment.id === id ? !comment.isLikeState : comment.isLikeState;
@@ -60,10 +65,12 @@ const movieCommentsModule = createSlice({
 
         // ユーザ（あるいはトークン）と一緒にメッセージ内容を保存する
         saveMessageInput: (state, action) => {
+            const selectedId = state.selectedCommentId;
             const text = action.payload;
-            // token(or User)はとりあえず固定（後で変更する）
-            const token = "9y7DyLFXQqVFsESjPNSBV9fq";
-            state.messageInput.push({ token: {token}, text: {text} });
+            state.list.forEach((comment, index) => {
+                comment.messageInput =
+                    selectedId === index ? text : comment.messageInput;
+            });
         },
     }
 });


### PR DESCRIPTION
### 概要
「いいね」「保存」「メッセージの送信」の変更は今までredux stateに保存されていなかったので，保存できるように処理を追加した．#44 では，local storageでredux stateが保存できるようになりどのページからでも同じstateを共有できるようになったので，例えば「いいね」を押したあと別のページに移動しても「いいね」された状態が残るようになった．

Close #48
 
### 具体的な変更内容
- ReceivedBoxとAfterSavingファイル内でuseDispatch Hookを用いて「いいね」「保存」の状態が保存（変更）可能に
- useSelectorで作られたuseMovieCommentsをimportすることで，どのファイルからでもstateの値を参照可能に
- 「メッセージの送信」でメッセージが保存可能に（現状，複数回送った場合は古いメッセージを上書きして，最新のメッセージだけ残るようにしている）

reduxの具体的なstateについては，front/src/modules/movieCommentsModule.js を参照